### PR TITLE
Changed default for no-console to warn.

### DIFF
--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -25,7 +25,7 @@ export default [
             }
         },
         rules: {
-            "no-console": ["error", {
+            "no-console": ["warn", {
                 allow: ["warn", "error"]
             }],
             "eol-last": ["error", "always"],


### PR DESCRIPTION
This has been interfering with my debugging consistently as eslint errors interrupts building and unit testing. 

warn accomplishes the same end result while not impeding development, testing, and debugging workflows. 